### PR TITLE
[parallel.simd.reference] Fix typo in SFINAE for assignment

### DIFF
--- a/src/simd.tex
+++ b/src/simd.tex
@@ -849,7 +849,7 @@ template<class U> reference operator=(U&& x) && noexcept;
   A copy of \tcode{*this}.
 
   \pnum\remarks
-  This function shall not participate in overload resolution unless \tcode{declval<value_type\&>() = std\colcol{}forward>U>(x)} is well-formed.
+  This function shall not participate in overload resolution unless \tcode{declval<value_type\&>() = std\colcol{}forward<U>(x)} is well-formed.
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
* It is currently invalid code.
* The typo does not appear in http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0214r9.pdf
