### PR TITLE
[parallel.simd.reference] Fix swap value_type params to be lvalues

### DIFF
--- a/src/simd.tex
+++ b/src/simd.tex
@@ -823,8 +823,8 @@ public:
   value_type operator--(int) && noexcept;
 
   friend void swap(reference&& a, reference&& b) noexcept;
-  friend void swap(value_type&& a, reference&& b) noexcept;
-  friend void swap(reference&& a, value_type&& b) noexcept;
+  friend void swap(value_type& a, reference&& b) noexcept;
+  friend void swap(reference&& a, value_type& b) noexcept;
 };
 \end{codeblock}
 


### PR DESCRIPTION
In the class definition of `simd::reference` the `value_type` parameters for
`swap()` are rvalue references.  This does not make sense; `swap()` must
accept lvalue-references to `value_type` to be able to exchange the referred
values.

The detailed description of `swap()` in §16 already correctly uses
lvalue-references for the `value_type` parameters.

Also, http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0214r9.pdf uses
lvalue-reference `value_type` parameters already in the `swap()` declaration
in the definition of the `simd::reference` class.