### PR TITLE
Fix an invalid angle bracket in simd spec.

### DIFF
--- a/src/simd.tex
+++ b/src/simd.tex
@@ -849,7 +849,7 @@ template<class U> reference operator=(U&& x) && noexcept;
   A copy of \tcode{*this}.
 
   \pnum\remarks
-  This function shall not participate in overload resolution unless \tcode{declval<value_type\&>() = std\colcol{}forward>U>(x)} is well-formed.
+  This function shall not participate in overload resolution unless \tcode{declval<value_type\&>() = std\colcol{}forward<U>(x)} is well-formed.
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
I am not quite sure if this document is alive in any shape or form right now, but one of the members of my NB noticed this typo during systematic review of the TS, so I'm leaving this for a future reference in case the spec gets reused as is.